### PR TITLE
Fix categories issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ from setuptools import setup, find_packages
 __plugin_name__ = "Telegramer"
 __author__ = "Noam"
 __author_email__ = "noamgit@gmail.com"
-__version__ = "2.1.3.0"
+__version__ = "2.1.3.1"
 __url__ = "https://github.com/noam09"
 __license__ = "GPLv3"
 __description__ = "Control Deluge using Telegram"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ from setuptools import setup, find_packages
 __plugin_name__ = "Telegramer"
 __author__ = "Noam"
 __author_email__ = "noamgit@gmail.com"
-__version__ = "2.1.1.0"
+__version__ = "2.1.3.0"
 __url__ = "https://github.com/noam09"
 __license__ = "GPLv3"
 __description__ = "Control Deluge using Telegram"

--- a/telegramer/core.py
+++ b/telegramer/core.py
@@ -618,8 +618,7 @@ class Core(CorePluginBase):
                 else:
                     if update.message.text in list(self.config["categories"].keys()):
                         # move_completed_path vs download_location
-                        self.opts["move_completed_path"] = self.config["categories"][update.message.text]
-                        self.opts["move_completed"] = True
+                        self.opts["download_location"] = self.config["categories"][update.message.text]
 
                     # If none of the existing categories were selected,
                     # maybe user is trying to save to a new directory
@@ -637,8 +636,7 @@ class Core(CorePluginBase):
                                 if not os.path.exists(otherpath):
                                     log.debug(prelog() + 'mkdir {}'.format(otherpath))
                                     os.makedirs(otherpath)
-                                self.opts["move_completed_path"] = otherpath
-                                self.opts["move_completed"] = True
+                                self.opts["download_location"] = otherpath
                         except Exception as e:
                             log.error(prelog() + str(e) + '\n' +
                                       traceback.format_exc())

--- a/telegramer/data/telegramer.js
+++ b/telegramer/data/telegramer.js
@@ -296,9 +296,9 @@ TelegramerPanel = Ext.extend(Ext.form.FormPanel, {
                 }
                 if (!Ext.isEmpty(config['categories'])) {
                     Object.entries(config['categories']).forEach(([cat, dir], index) => {
+                        if (index >= 3) return;
                         config[`cat${index+1}`] = cat;
                         config[`dir${index+1}`] = dir;
-                        if (index >= 3) return;
                     });
                     delete config['categories'];
                 }

--- a/telegramer/data/telegramer.js
+++ b/telegramer/data/telegramer.js
@@ -295,13 +295,11 @@ TelegramerPanel = Ext.extend(Ext.form.FormPanel, {
                     config['urllib3_proxy_kwargs_password'] = config['urllib3_proxy_kwargs_password']
                 }
                 if (!Ext.isEmpty(config['categories'])) {
-                    let i = 1;
-                    for (const [cat, dir] = Object.entries(config['categories'])) {
-                        config[`cat${i}`] = cat;
-                        config[`dir${i}`] = dir;
-                        i++;
-                        if (i >= 4) break;
-                    }
+                    Object.entries(config['categories']).forEach(([cat, dir], index) => {
+                        config[`cat${index+1}`] = cat;
+                        config[`dir${index+1}`] = dir;
+                        if (index >= 3) return;
+                    });
                     delete config['categories'];
                 }
                 if (!Ext.isEmpty(config['cat1'])) {


### PR DESCRIPTION
Categories now can define downloading directory, when labels can be used to move completed downloads to new location.

This is helpful when torrent content has been changed (new episode released) and you only want to download a difference. It was impossible using labels with configured “Move completed location” because deluge do not take into consideration if content location has been changed and re-downloading full content to “download” directory and since download complete - move it to label location (overwriting files)